### PR TITLE
Removed reliance on facades.

### DIFF
--- a/src/Nicolaslopezj/Searchable/SearchableTrait.php
+++ b/src/Nicolaslopezj/Searchable/SearchableTrait.php
@@ -1,5 +1,7 @@
 <?php namespace Nicolaslopezj\Searchable;
 
+use Illuminate\Database\Query\Expression;
+
 /**
  * Trait SearchableTrait
  * @package Nicolaslopezj\Searchable
@@ -71,7 +73,7 @@ trait SearchableTrait
      * @param $selects
      */
     protected function addSelectsToQuery(&$query, $selects) {
-        $selects = \DB::raw(join(' + ', $selects) . ' as relevance');
+        $selects = new Expression(join(' + ', $selects) . ' as relevance');
         $query->select([$this->getTable() . '.*', $selects]);
     }
 


### PR DESCRIPTION
Changed the reference of the `raw` method on the `DB` facade to instead use a new instance of `Illuminate\Database\Query\Expression`. 

This eliminates the reliance on facades, making the trait independent of the framework and can now be used with Eloquent outside of Laravel.
