### PR TITLE
Make joins although search is empty

### DIFF
--- a/src/Nicolaslopezj/Searchable/SearchableTrait.php
+++ b/src/Nicolaslopezj/Searchable/SearchableTrait.php
@@ -17,7 +17,9 @@ trait SearchableTrait
      */
     public function scopeSearch($query, $search) {
 
-        if (!$search) {
+        if ( ! $search)
+        {
+            $this->makeJoins($query);
             return $query;
         }
 


### PR DESCRIPTION
Using a join like in your example: https://github.com/nicolaslopezj/searchable#usage

You can have an error trying to order by a related table field if the search is empty.

``` php
$terms   = Input::get('search');
$results = User::search($terms)->orderBy('posts.title');

// If $terms is empty => ERROR
```
