### PR TITLE
Bug fix in group by with joins

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -120,14 +120,25 @@ trait SearchableTrait
     protected function makeGroupBy(&$query)
     {
         $driver = $this->getDatabaseDriver();
-
         if ($driver == 'sqlsrv') {
             $columns = $this->getTableColumns();
         } else {
-            $columns = $this->primaryKey;
-        }
+            $id = $this->getTable() . '.' .$this->primaryKey;
+            $joins = array_keys(($this->getJoins()));
 
-        $query->groupBy($columns);
+            foreach ($this->getColumns() as $column => $relevance) {
+
+                array_map(function($join) use ($column, $query){
+
+                    if(Str::contains($column, $join)){
+                        $query->groupBy("$column");
+                    }
+
+                }, $joins);
+
+            }
+        }
+        $query->groupBy($id);
     }
 
     /**


### PR DESCRIPTION
I tried to use the search with joins ex:
  protected $ searchable = [
         'columns' => [
             'cities.name' => 10,
             'states.name' => 10
         ]
         'joins' => [
             'states' => ['states.id', 'cities.state_id'],
         ]
     ];
but there errors in joins with group by, and decided that way.