### PR TITLE
fix Class 'Nicolaslopezj\Searchable\Str' not found

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Query\Expression;
 use Config;
+use Str;
 
 /**
  * Trait SearchableTrait


### PR DESCRIPTION
fix class Str not found introduced from previous commit.