### PR TITLE
Fix scopeSearch, it returned the cloned query $q instead of new $query

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -33,7 +33,7 @@ trait SearchableTrait
 
         if ( ! $search)
         {
-            return $q;
+            return $query;
         }
 
         $words = explode(' ', $search);
@@ -60,7 +60,7 @@ trait SearchableTrait
 
         $this->mergeQueries($query, $q);
 
-        return $q;
+        return $query;
     }
 
     /**


### PR DESCRIPTION
The method scopeSearch returns the old $q query cloned at the first line. 
I've change it to $query, because the $q throw a QueryException Column Not Found.