### PR TITLE
Add the possibility to search for the whole text

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -25,7 +25,7 @@ trait SearchableTrait
      * @param float|null $threshold
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeSearch(Builder $q, $search, $threshold = null)
+    public function scopeSearch(Builder $q, $search, $threshold = null, $entireText = false)
     {
         $query = clone $q;
         $query->select($this->getTable() . '.*');
@@ -38,6 +38,12 @@ trait SearchableTrait
 
         $search = strtolower($search);
         $words = explode(' ', $search);
+        if ( $entireText === true )
+        {
+            array_unshift($words, $search);
+        }
+
+        
         $selects = [];
         $this->search_bindings = [];
         $relevance_count = 0;


### PR DESCRIPTION
If i'm searching for **Saving Private**, i would like that **Saving Private Ryan** have a better result that **Saving The animals, private detective** (that movie doesn't exists). 

I implemented the code in a NON breaking change way, so the flag is false by default. You may want to set this to true often, but i'll let you decide what's the best