### PR TITLE
Improved EntireWord Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,17 @@ class User extends \Eloquent
 
 ####Search:
 ```php
-$search = User::search('Sed neque labore')->get();
+$search = User::search('Sed neque labore', null, true)->get();
 ```
 
 ####Result:
 ```sql
 select `users`.*, 
+
+-- If third parameter is set as true, it will check if the column starts with the search
+-- if then it adds relevance * 30
+-- this ensures that relevant results will be at top
+(case when first_name LIKE 'Sed neque labore%' then 300 else 0 end) + 
 
 -- For each column you specify makes 3 "ifs" containing 
 -- each word of the search input and adds relevace to 


### PR DESCRIPTION
This pull request implements a better EntireWord Search that gives more relevance to results that starts with the entire search...

Some cases like this search: `Lucas do rio`

May not show the result `Lucas do Rio Verde` as first result in this table:

```
Lucas do Rio Verde
Bahia dos santos do Brasil (Rio grande do sul)
Do do do do (Rio grande do sul)
```

In my PR:

* I give a relevance multiplier of `30` to a search `LIKE 'lucas do%'`. This fix the problem above.

* I added a `trim()` to search, to avoid blank spaces to causing performance issues.

* Moved $like_comparator variable from `filterQueryWithRelevance()` to `getSearchQuery()` method