### PR TITLE
fix when not using decimal points for numbers

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -179,6 +179,9 @@ trait SearchableTrait
     protected function filterQueryWithRelevance(Builder $query, array $selects, $relevance_count)
     {
         $comparator = $this->getDatabaseDriver() != 'mysql' ? implode(' + ', $selects) : 'relevance';
+
+        $relevance_count=number_format($relevance_count,2,'.','');
+
         $query->havingRaw("$comparator > $relevance_count");
         $query->orderBy('relevance', 'desc');
 


### PR DESCRIPTION
In case you're working with locales where decimal point are not used, FE, using commas, relevance_count should be converted for the query not to fail.

This happens when the division is not whole and it has decimals.