### PR TITLE
Add a "where" clause to the inner select

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -27,6 +27,11 @@ trait SearchableTrait
      */
     public function scopeSearch(Builder $q, $search, $threshold = null, $entireText = false)
     {
+        return $this->scopeSearchRestricted($q, $search, null, $threshold, $entireText);
+    }
+
+    public function scopeSearchRestricted(Builder $q, $search, $restriction, $threshold = null, $entireText = false)
+    {
         $query = clone $q;
         $query->select($this->getTable() . '.*');
         $this->makeJoins($query);
@@ -65,6 +70,10 @@ trait SearchableTrait
         $this->makeGroupBy($query);
 
         $this->addBindingsToQuery($query, $this->search_bindings);
+
+        if(is_callable($restriction)) {
+            $query = $restriction($query);
+        }
 
         $this->mergeQueries($query, $q);
 


### PR DESCRIPTION
I have a case where I required to add a "where" into the inner select, e.g.

```sql
select 
  * 
from 
  (select 
      `products`.*, 
      (case when LOWER(`product_localizations`.`name`) LIKE 'word' then 750 else 0 end) + ...
   from 
      `products` 
   left join 
      `product_localizations` on `products`.`id` = `product_localizations`.`product_id` 
   where 
      `product_localizations`.`language_id` in ('41')
   group by 
      ...
  having 
      relevance > 22.50 
  order by 
      `relevance` desc
  ) 
as 
  `products`
``` 
I need this since I only want to search trough the localizations of the users's language. So I propose this change where a second method (```searchRestricted```) allows to modify the search query before merging:

```php
$this->result = Product::searchRestricted("word", function($query) {
            return $query->where('product_localizations.language_id', 41);
        })->get();
```
I didn't change the original ```search``` because I don't want to break the interface.