### PR TITLE
Use the model's connection to determine database driver.

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -77,8 +77,7 @@ trait SearchableTrait
      * @return array
      */
     protected function getDatabaseDriver() {
-        $key = Config::get('database.default');
-        return Config::get('database.connections.' . $key . '.driver');
+        return Config::get('database.connections.' . $this->connection . '.driver');
     }
 
     /**


### PR DESCRIPTION
When using different connections for different models, using the default connection to determine the database driver may cause issues, especially when different models use different database drivers. This pull request fixes this issue by always using the current model's connection.