### PR TITLE
Fix being unable to disable threshold

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -60,7 +60,13 @@ trait SearchableTrait
         }
 
         $this->addSelectsToQuery($query, $selects);
-        $this->filterQueryWithRelevance($query, $selects, $threshold ?: ($relevance_count / 4));
+
+        // Default the threshold if no value was passed.
+        if (is_null($threshold)) {
+            $threshold = $relevance_count / 4;
+        }
+
+        $this->filterQueryWithRelevance($query, $selects, $threshold);
 
         $this->makeGroupBy($query);
 


### PR DESCRIPTION
The threshold was defaulting to `relevance_count / 4` if the passed threshold value was not truthy, causing the method for disabling the threshold - passing zero, as noted in the documentation - to fail.

This patch changes the behaviour such the threshold is only calculated if the given value is null, which is what the value defaults to if it is not passed.  Any other value that is passed to the function will always be respected.