### PR TITLE
Remove Laravel aliases and call facades directly

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -2,8 +2,8 @@
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
-use Config;
-use DB;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 /**


### PR DESCRIPTION
This is so that there are no collisions or issues if someone renames the alias for DB or Config within their Laravel app. I actually had to rename both of these aliases (unfortunately I have some legacy code using PEAR's DB class :cry:) in my Laravel app.

@nicolaslopezj - do you see any issues doing this? Thought this might make this package a bit more robust. :sunglasses: