### PR TITLE
Added average aggregate function to relevance scores (fixes #75)

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -184,7 +184,7 @@ trait SearchableTrait
      */
     protected function addSelectsToQuery(Builder $query, array $selects)
     {
-        $selects = new Expression(implode(' + ', $selects) . ' as relevance');
+        $selects = new Expression('avg(' . implode(' + ', $selects) . ') as relevance');
         $query->addSelect($selects);
     }
 


### PR DESCRIPTION
This pull request fixes #75 and possibly more issues. The problem is that a GROUP BY clause is used (to remove duplicates?), but there is no aggregate over the relevance score.