### PR TITLE
Added the option to control whether or not to keep duplicates in the results

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -115,13 +115,13 @@ trait SearchableTrait
      *
      * @return array
      */
-    protected function getAllowDuplicates()
+    protected function getGroupBy()
     {
-        if (array_key_exists('duplicates', $this->searchable)) {
-            return $this->searchable['duplicates'];
+        if (array_key_exists('groupBy', $this->searchable)) {
+            return $this->searchable['groupBy'];
         }
 
-        return true;
+        return false;
     }
 
     /**
@@ -168,17 +168,19 @@ trait SearchableTrait
      */
     protected function makeGroupBy(Builder $query)
     {
-        $driver = $this->getDatabaseDriver();
-
-        if ($driver == 'sqlsrv') {
-            $columns = $this->getTableColumns();
+        if ($groupBy = $this->getGroupBy()) {
+            $query->groupBy($groupBy);
         } else {
-            $columns = $this->getTable() . '.' .$this->primaryKey;
-        }
+            $driver = $this->getDatabaseDriver();
 
-        $query->groupBy($columns);
+            if ($driver == 'sqlsrv') {
+                $columns = $this->getTableColumns();
+            } else {
+                $columns = $this->getTable() . '.' .$this->primaryKey;
+            }
 
-        if ($this->getAllowDuplicates()) {
+            $query->groupBy($columns);
+
             $joins = array_keys(($this->getJoins()));
 
             foreach ($this->getColumns() as $column => $relevance) {
@@ -187,7 +189,6 @@ trait SearchableTrait
                         $query->groupBy($column);
                     }
                 }, $joins);
-
             }
         }
     }

--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -111,6 +111,20 @@ trait SearchableTrait
     }
 
     /**
+     * Returns whether or not to keep duplicates.
+     *
+     * @return array
+     */
+    protected function getAllowDuplicates()
+    {
+        if (array_key_exists('duplicates', $this->searchable)) {
+            return $this->searchable['duplicates'];
+        }
+
+        return true;
+    }
+
+    /**
      * Returns the table columns.
      *
      * @return array
@@ -155,25 +169,27 @@ trait SearchableTrait
     protected function makeGroupBy(Builder $query)
     {
         $driver = $this->getDatabaseDriver();
+
         if ($driver == 'sqlsrv') {
             $columns = $this->getTableColumns();
         } else {
-            $id = $this->getTable() . '.' .$this->primaryKey;
+            $columns = $this->getTable() . '.' .$this->primaryKey;
+        }
+
+        $query->groupBy($columns);
+
+        if ($this->getAllowDuplicates()) {
             $joins = array_keys(($this->getJoins()));
 
             foreach ($this->getColumns() as $column => $relevance) {
-
-                array_map(function($join) use ($column, $query){
-
-                    if(Str::contains($column, $join)){
-                        $query->groupBy("$column");
+                array_map(function ($join) use ($column, $query) {
+                    if (Str::contains($column, $join)) {
+                        $query->groupBy($column);
                     }
-
                 }, $joins);
 
             }
         }
-        $query->groupBy($id);
     }
 
     /**


### PR DESCRIPTION
Using joins to allow a broader search can lead to duplicate rows if the joined tables are not physically shown in the results list. With this pull request the developer can choose whether or not to keep duplicates by manually setting the group by clause.

    class Account extends Model
    {
        use SearchableTrait;

        /**
         * @var array
         */
        protected $searchable = [
            'columns' => [
                // ...
            ],
            'joins' => [
                // ...
            ],
            'groupBy' => 'accounts.id' // defaults to false
        ];

The default value of the `groupBy` option is false, in which case the old group by clause is used. Otherwise, the provided value will be used to group by. Furthermore, this pull requests fixes a bug where `$ids` is undefined in the case of a SQLSRV driver.