### PR TITLE
Use MAX function for relevance aggregation

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -202,7 +202,7 @@ trait SearchableTrait
      */
     protected function addSelectsToQuery(Builder $query, array $selects)
     {
-        $selects = new Expression('avg(' . implode(' + ', $selects) . ') as relevance');
+        $selects = new Expression('max(' . implode(' + ', $selects) . ') as relevance');
         $query->addSelect($selects);
     }
 


### PR DESCRIPTION
As mentioned in #87 

>One comment however - isn't it better to use the MAX function here instead of average?
>
>For example, imagine we had a Post model with a relationship to comments, and we have 10 comments to join. If our search term only matches one of those comments, we surely want that post's relevance to be the weight that we give a comment match (e.g. a weight of 10). Using AVG, with 10 comments and a weight of 10, we would get a post relevance of 1 in this case - which isn't the weight of 10 we defined in the model. If we used MAX however, then the returned relevance of 10 will cascade up to the Post.
>
>Am I thinking through that correctly? I'll submit a PR changing the function to max, and we can discuss it there.