### PR TITLE
Phpdoc, fix using eloquent table prefix

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -9,6 +9,10 @@ use Illuminate\Support\Str;
 /**
  * Trait SearchableTrait
  * @package Nicolaslopezj\Searchable
+ * @property array $searchable
+ * @property string $table
+ * @property string $primaryKey
+ * @method string getTable()
  */
 trait SearchableTrait
 {
@@ -314,10 +318,11 @@ trait SearchableTrait
      * @param \Illuminate\Database\Eloquent\Builder $original
      */
     protected function mergeQueries(Builder $clone, Builder $original) {
-        if($this->getDatabaseDriver() == 'pgsql'){
-            $original->from(DB::connection($this->connection)->raw("({$clone->toSql()}) as {$this->getTable()}"));
-        }else{
-            $original->from(DB::connection($this->connection)->raw("({$clone->toSql()}) as `{$this->getTable()}`"));
+        $tableName = DB::connection($this->connection)->getTablePrefix() . $this->getTable();
+		if ($this->getDatabaseDriver() == 'pgsql') {
+            $original->from(DB::connection($this->connection)->raw("({$clone->toSql()}) as {$tableName}"));
+        } else {
+            $original->from(DB::connection($this->connection)->raw("({$clone->toSql()}) as `{$tableName}`"));
         }
         $original->mergeBindings($clone->getQuery());
     }


### PR DESCRIPTION
If you use custom table prefix in laravel orm database configuration you should set it in query "select (conds) as `{prefix}table`" to avoid conflicts with other traits like softDeletes (default eloquent trait).
Issue was descripted in https://github.com/nicolaslopezj/searchable/issues/101