### PR TITLE
Fixes #66

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -236,7 +236,7 @@ trait SearchableTrait
 
         $relevance_count=number_format($relevance_count,2,'.','');
 
-        $query->havingRaw("$comparator > $relevance_count");
+        $query->havingRaw("$comparator >= $relevance_count");
         $query->orderBy('relevance', 'desc');
 
         // add bindings to postgres


### PR DESCRIPTION
This commit fixes Issue #66 

Just changed the relevance check from `>` to `>=` because of the situation where the relevante is equal to threshold no results was returned.