### PR TITLE
fix for bindings order when using where clause

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -87,7 +87,11 @@ trait SearchableTrait
 
         $this->makeGroupBy($query);
 
+        $clone_bindings = $query->getBindings();
+        $query->setBindings([]);
+
         $this->addBindingsToQuery($query, $this->search_bindings);
+        $this->addBindingsToQuery($query, $clone_bindings);
 
         if(is_callable($restriction)) {
             $query = $restriction($query);
@@ -337,6 +341,12 @@ trait SearchableTrait
         } else {
             $original->from(DB::connection($this->connection)->raw("({$clone->toSql()}) as `{$tableName}`"));
         }
-        $original->mergeBindings($clone->getQuery());
+
+        $original->setBindings(
+            array_merge_recursive(
+                $clone->getBindings(),
+                $original->getBindings()
+            )
+        );
     }
 }


### PR DESCRIPTION
The bindings order were wrong. The following code includes published scope which is `$query->where('published_at', '<=', Carbon::now());` .. 

`$articles = Article::with('category')->published()->search($request->get('q'))->paginate(10);`

params are:
0	2016-12-10 10:56:21
1	2016-12-10 10:56:21
2	test
3	test%
4	%test%
5	test
6	test%
7	%test%

which is wrong. 
Correct Params should have been with this order : 

```
0	test
1	test%
2	%test%
3	test
4	test%
5	%test%
6	2016-12-10 10:56:21
7	2016-12-10 10:56:21

```

My sql was like : (date and query params were at wrong places.)
select count(*) as aggregate from (select articles.*, max((case when LOWER(articles.title) **LIKE '2016-12-10 10:56:21'**' then 300 else 0 end) ..... bla bla bla.... having relevance > 7.50 order by relevance desc) as articles where published_at <= '%test%'

So made the changes. That fixed my issue for me . I am not sure if it breaks anything. So someone else should test it. 

I am using laravel 5.3

have a good day.
