### PR TITLE
Fix bug #93 completing Tamrael's modification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,1 +1,0 @@
-.DS_Store

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -322,11 +322,14 @@ trait SearchableTrait
             $original->from(DB::connection($this->connection)->raw("({$clone->toSql()}) as `{$tableName}`"));
         }
 
-        $original->setBindings(
-            array_merge_recursive(
-                $clone->getBindings(),
-                $original->getBindings()
-            )
+        // First create a new array merging bindings
+        $mergedBindings = array_merge_recursive(
+            $clone->getBindings(),
+            $original->getBindings()
         );
+
+        // Then apply bindings WITHOUT global scopes which are already included. If not, there is a strange behaviour
+        // with some scope's bindings remaning
+        $original->withoutGlobalScopes()->setBindings($mergedBindings);
     }
 }


### PR DESCRIPTION
Even with Tamrael's modifications I still had the issue that using search with global scopes did not work. I noticed that even assigning new bindings to the original request in `mergeQueries` an old binding was still there.
For example, if my original bindigns where
`
[ 0 => 'binding 1', 1 => 'binding 2' ]
`
Then new bindings would be
`
[ 0 => 'binding 1', 1 => 'Search pattern', 2 => 'Search pattern%', 3 => '%Search pattern%', 4 => 'binding 1',  ]
`
The first binding should not be there. The solution was to add new bindings out of the scope adding `withoutGlobalScopes`