### PR TITLE
fixed pgsql bug

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -242,7 +242,12 @@ trait SearchableTrait
 
         $relevance_count=number_format($relevance_count,2,'.','');
 
-        $query->havingRaw("$comparator >= $relevance_count");
+        if ($this->getDatabaseDriver() == 'mysql') {
+            $bindings = [];
+        } else {
+            $bindings = $this->search_bindings;
+        }
+        $query->havingRaw("$comparator >= $relevance_count", $bindings);
         $query->orderBy('relevance', 'desc');
 
         // add bindings to postgres
@@ -339,4 +344,3 @@ trait SearchableTrait
         $original->withoutGlobalScopes()->setBindings($mergedBindings);
     }
 }
-


### PR DESCRIPTION
The code for non-mysql drivers produced a bug, as the `$selects` contained placeholders but no parameters were bound to these placeholders. Simply adding the `$this->search_bindings` to the statement fixed the bug