### PR TITLE
Update SearchableTrait.php

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -85,7 +85,7 @@ trait SearchableTrait
 
         // Default the threshold if no value was passed.
         if (is_null($threshold)) {
-            $threshold = $relevance_count / 4;
+            $threshold = $relevance_count / count($this->getColumns());
         }
 
         if (!empty($selects)) {


### PR DESCRIPTION
threshold should be divided by total number of columns in order to keep the spread and relevance.
this is important when there are a lot of columns in the select  query (or a very big table with a lot of columns).

@nicolaslopezj please accept this PR.