### PR TITLE
Allow Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/database": "4.2.x|~5.0",
+        "illuminate/database": "^4.2 | ^5.0 | ^6.0",
         "ext-mbstring": "*"
     },
     "autoload": {


### PR DESCRIPTION
As there is no breaking change for illuminate/database from 5 to 6, allowing Laravel 6.0 is OK.

This is an alternative of #198 with wider and normalized versions range.