### PR TITLE
Fix: global scopes being called twice

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -39,7 +39,7 @@ trait SearchableTrait
     public function scopeSearchRestricted(Builder $q, $search, $restriction, $threshold = null, $entireText = false, $entireTextOnly = false)
     {
         $query = clone $q;
-        $query->select($this->getTable() . '.*');
+        $query->select($this->getTable() . '.*')->withoutGlobalScopes();
         $this->makeJoins($query);
 
        if ($search === false)


### PR DESCRIPTION
This commit is fix when searchable try to clone query and select existing query whicis already has global query scope.