### PR TITLE
Fix composer versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0|>=7.1|^8.2",
-        "illuminate/database": ">=4.2|^11.0",
+        "php": ">=5.4.0",
+        "illuminate/database": ">=4.2",
         "ext-mbstring": "*"
     },
     "autoload": {


### PR DESCRIPTION
from ChatGPT:

**composer.json** contain significant redundancy.

For **php**:
`>=5.4.0` already means "**any version from 5.4.0 onwards.**"

Adding `|>=7.1|^8.2` after that **is redundant**. If a version is `>=5.4.0`, it inherently includes `>=7.1` and `>=8.2`. Composer won't interpret this | (OR) logic as you intend for a single dependency's lower bound.

For **illuminate/database**:
`>=4.2` already means "**any version from 4.2.0 onwards.**"

Adding `|^11.0` after that **is redundant**. If a version is `>=4.2`, it inherently includes `>=11.0`


My suggestion on https://github.com/nicolaslopezj/searchable/pull/232#discussion_r2130211607 was ignored.
